### PR TITLE
Error: failed to initialize with nil as params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 .ruby-version
+.idea

--- a/lib/tainbox/instance_methods.rb
+++ b/lib/tainbox/instance_methods.rb
@@ -16,6 +16,7 @@ module Tainbox::InstanceMethods
 
   # TODO Reset attributes that are missing in parameter hash
   def attributes=(attributes)
+    attributes ||= {}
     attributes = attributes.symbolize_keys
     self.class.tainbox_attributes.each do |attribute|
 


### PR DESCRIPTION
In some situations, form classes receives `nil` as a param. For example, it is a normal situation with a get method, when you haven't form params on first call, but should build the form. In this case two variants are possible, by using params.fetch(namespace, {}) and by handling this inside tainbox. I think, the second is beter
