### PR TITLE
Method for "patching" attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ person.attributes = {}
 person.attributes # => { :name => "person_20", :age => 20 }
 ```
 
-*NOTE* There exists two instance methods `attributes=` and `patch_attrubutes(attributes)`
-which can reassign your params. Difference is that the first one will fill missing
-keys with `nil`, but the second one - will reassign only keys existing in `attributes` hash.
+*NOTE* There are two ways to change attributes in bulk. attributes= replaces missing values
+with nils or default values, while patch_attributes leaves missing attributes untouched.
 
 ## But what's wrong with Virtus?
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ person.attributes = {}
 person.attributes # => { :name => "person_20", :age => 20 }
 ```
 
+*NOTE* There exists two instance methods `attributes=` and `patch_attrubutes(attributes)`
+which can reassign your params. Difference is that the first one will fill missing
+keys with `nil`, but the second one - will reassign only keys existing in `attributes` hash.
+
 ## But what's wrong with Virtus?
 
 Observe:

--- a/lib/tainbox/instance_methods.rb
+++ b/lib/tainbox/instance_methods.rb
@@ -45,6 +45,14 @@ module Tainbox::InstanceMethods
     tainbox_provided_attributes.include?(attribute.to_sym)
   end
 
+  def patch_attributes(attributes)
+    if attributes.respond_to?(:to_h)
+      attributes.to_h.each { |key, value| send("#{key}=", value) if respond_to?("#{key}=") }
+    else
+      raise ArgumentError, 'Attributes can only be assigned via objects which respond to #to_h'
+    end
+  end
+
   def as_json(*args)
     attributes.as_json(*args)
   end

--- a/lib/tainbox/version.rb
+++ b/lib/tainbox/version.rb
@@ -1,3 +1,3 @@
 module Tainbox
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/spec/tainbox_spec.rb
+++ b/spec/tainbox_spec.rb
@@ -143,4 +143,27 @@ describe Tainbox do
       end
     end
   end
+
+  describe 'patching params' do
+    let(:person) do
+      Class.new do
+        include Tainbox
+
+        attribute :name, default: 'Oliver'
+        attribute :age, Integer
+
+        def name
+          super.strip
+        end
+      end
+    end
+
+    let(:attributes) { Hash[name: 'John'] }
+
+    it 'changes only provided attributes' do
+      oliver = person.new(age: 21)
+      expect { oliver.patch_attributes(attributes) }.not_to change { oliver.age }
+      expect(oliver.name).to eq('John')
+    end
+  end
 end


### PR DESCRIPTION
I wrote the method which will reassing only keys in params hash:

```ruby
class Person
  inlcude Tainbox

  attribute :name
  attribute :age
end
```

```ruby
person = Person.new(age: 21, name: "Oliver")
person.patch_attributes(name: "Queen")
person.attrubutes # => { age: 21, name: "Queen" }
```