### PR TITLE
Fix #attribute_provided? behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,18 +64,27 @@ end
 
 ### #attribute_provided?
 
-Attribute is considered provided if its setter was explicitly invoked via a setter, `.new`, or `#attributes=` or it has a default value.
+Attribute is considered provided if its setter was explicitly invoked via a setter, `.new`, or `#attributes=`.
 
 ``` ruby
 class Person
   include Tainbox
-  attribute :name, default: 'John'
+  attribute :name, default: 'Anonymous'
   attribute :age
 end
 
-person = Person.new
-person.attribute_provided?(:age) # => false
+person = Person.new('age' => '24')
+
+person.attribute_provided?(:name) # => false
+person.attribute_provided?(:age) # => true
+
+person.name = 'John'
 person.attribute_provided?(:name) # => true
+person.attribute_provided?(:age) # => true
+
+person.attributes = {}
+person.attribute_provided?(:name) # => false
+person.attribute_provided?(:age) # => false
 ```
 
 ### Disabling automatic attribute readers and writers

--- a/lib/tainbox/attribute_definer.rb
+++ b/lib/tainbox/attribute_definer.rb
@@ -41,14 +41,14 @@ class Tainbox::AttributeDefiner
       end
 
       define_method("tainbox_set_default_#{attribute}") do
+        tainbox_unregister_attribute_provided(attribute)
+
         if args.has_key?(:default)
-          tainbox_register_attribute_provided(attribute)
           value = args[:default].deep_dup
           value = Tainbox::DeferredValue.new(value) if value.is_a?(Proc)
           instance_variable_set(:"@tainbox_#{attribute}", value)
 
         else
-          tainbox_unregister_attribute_provided(attribute)
           instance_variable_set(:"@tainbox_#{attribute}", nil)
         end
       end

--- a/spec/tainbox_spec.rb
+++ b/spec/tainbox_spec.rb
@@ -23,7 +23,7 @@ describe Tainbox do
     person.attributes = {}
     expect(person.name).to eq('Oliver')
     expect(person.age).to be_nil
-    expect(person.attribute_provided?(:name)).to be_truthy
+    expect(person.attribute_provided?(:name)).to be_falsey
     expect(person.attribute_provided?(:age)).to be_falsey
 
     expect(person.attributes).to eq(name: 'Oliver', age: nil)


### PR DESCRIPTION
`#attribute_provided?` should return `false` for attributes with default values.

```Ruby
class Foo
  include Tainbox

  attribute :bar, Integer
  attribute :baz, Integer, default: 0
end

foo = Foo.new

expect(foo.bar).to eq(nil)
expect(foo.attribute_provided?(:bar)).to be_falsey

expect(person.baz).to eq(0)
expect(person.attribute_provided?(:baz)).to be_falsey
```
