### PR TITLE
Fix converting in Integer type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,3 +54,8 @@ semantics
 ## 2.1.1
 
 * Fix `Time` converter
+
+## 2.1.2
+
+* Fix Integer type casting: Integer parses strings with leading zeros as numbers in octal number system
+* Update version of bundler

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ end
 
 All converters return nil if conversion could not be made.
 
-- Integer
+- Integer (*converts from strings with decimal base*)
 - Float
 - String
 - Symbol

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ end
 
 All converters return nil if conversion could not be made.
 
-- Integer (*converts from strings with decimal base*)
+- Integer (*converts from strings using decimal base*)
 - Float
 - String
 - Symbol

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ end
 
 All converters return nil if conversion could not be made.
 
-- Integer (*converts from strings using decimal base*)
+- Integer (*string parsed as numbers in decimal number system*)
 - Float
 - String
 - Symbol

--- a/lib/tainbox/type_converter.rb
+++ b/lib/tainbox/type_converter.rb
@@ -32,7 +32,7 @@ class Tainbox::TypeConverter
 end
 
 Tainbox.define_converter(Integer) do
-  Integer(value) rescue nil
+  value.is_a?(String) ? Integer(value, 10) : Integer(value) rescue nil
 end
 
 Tainbox.define_converter(Float) do

--- a/lib/tainbox/version.rb
+++ b/lib/tainbox/version.rb
@@ -1,3 +1,3 @@
 module Tainbox
-  VERSION = '2.1.2'
+  VERSION = '2.1.3'
 end

--- a/spec/tainbox_spec.rb
+++ b/spec/tainbox_spec.rb
@@ -167,7 +167,7 @@ describe Tainbox do
     end
   end
 
-  describe 'convert to integer string with radix indicators' do
+  describe "Integer type" do
     let(:person) do
       Class.new do
         include Tainbox
@@ -176,26 +176,22 @@ describe Tainbox do
       end
     end
 
-    let(:attributes) { Hash[age: "014"] }
+    let(:attributes) { Hash[age: age] }
 
-    it "uses decimal number system as base" do
-      expect(person.new(attributes).age).to eq(14)
-    end
-  end
+    describe 'string with radix indicators' do
+      let(:age) { "014" }
 
-  describe 'float number with Integer type' do
-    let(:person) do
-      Class.new do
-        include Tainbox
-
-        attribute :age, Integer
+      it 'uses decimal number system as base' do
+        expect(person.new(attributes).age).to eq(14)
       end
     end
 
-    let(:attributes) { Hash[age: 14.2] }
+    describe 'float number' do
+      let(:age) { 14.2 }
 
-    it "converts properly" do
-      expect(person.new(attributes).age).to eq(14)
+      it 'converts properly' do
+        expect(person.new(attributes).age).to eq(14)
+      end
     end
   end
 end

--- a/spec/tainbox_spec.rb
+++ b/spec/tainbox_spec.rb
@@ -166,4 +166,36 @@ describe Tainbox do
       expect(oliver.name).to eq('John')
     end
   end
+
+  describe 'convert to integer string with radix indicators' do
+    let(:person) do
+      Class.new do
+        include Tainbox
+
+        attribute :age, Integer
+      end
+    end
+
+    let(:attributes) { Hash[age: "014"] }
+
+    it "uses decimal number system as base" do
+      expect(person.new(attributes).age).to eq(14)
+    end
+  end
+
+  describe 'float number with Integer type' do
+    let(:person) do
+      Class.new do
+        include Tainbox
+
+        attribute :age, Integer
+      end
+    end
+
+    let(:attributes) { Hash[age: 14.2] }
+
+    it "converts properly" do
+      expect(person.new(attributes).age).to eq(14)
+    end
+  end
 end

--- a/tainbox.gemspec
+++ b/tainbox.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activesupport'
 
-  spec.add_development_dependency 'bundler', '~> 1.8'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
From documentation about [Kernel#Integer](https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-Integer):
```
If arg is a String, when base is omitted or equals zero, radix indicators (0, 0b, and 0x) are honored.
```
So, usually, when a string is converted to a number, assumed that the string has a decimal number system
But now:
```ruby
class Test
  include Tainbox

  attribute :age, :Integer
end

t = Test.new(age: "012")
p t.age #=> 10
```
